### PR TITLE
print out internal binary versions

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,15 +64,16 @@ func main() {
 	mainArgs, etcdArgs := filterArgs()
 	fs.Parse(mainArgs)
 
-	if showVersion {
-		fmt.Println("etcd-starter version", version)
-		os.Exit(0)
-	}
-
 	dir := os.Getenv("ETCD_INTERNAL_BINARY_DIR")
 	if dir == "" {
 		dir = defaultInternalBinaryDir
 	}
+
+	if showVersion {
+		printVersions(dir)
+		os.Exit(0)
+	}
+
 	starter.StartDesiredVersion(dir, etcdArgs)
 }
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,31 @@
 package main
 
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+)
+
 const version = "0.0.2+git"
+
+func printVersions(binarydir string) {
+	fmt.Println("etcd-starter version", version)
+
+	binary1 := path.Join(binarydir, "1", "etcd")
+	binary2 := path.Join(binarydir, "2", "etcd")
+
+	if _, err := os.Stat(binary1); err == nil {
+		output, err := exec.Command(binary1, "--version").Output()
+		if err == nil {
+			fmt.Print("internal version 1: " + string(output))
+		}
+	}
+
+	if _, err := os.Stat(binary2); err == nil {
+		output, err := exec.Command(binary2, "--version").Output()
+		if err == nil {
+			fmt.Print("internal version 2: " + string(output))
+		}
+	}
+}


### PR DESCRIPTION
/cc @crawford 

```
etcd-starter version 0.0.2+git
internal version 1: etcd version 0.4.8+git
internal version 2: etcd version 2.0.4+git
```