### PR TITLE
starter: exec etcd when asking for --help

### DIFF
--- a/starter/starter.go
+++ b/starter/starter.go
@@ -67,7 +67,7 @@ func StartDesiredVersion(binDir string, args []string) {
 	}
 
 	ver := checkInternalVersion(fs)
-	fmt.Printf("etcd-starter: starting etcd version %s", ver)
+	fmt.Printf("etcd-starter: starting etcd version %s\n", ver)
 	var p string
 	switch ver {
 	case internalV1:
@@ -77,8 +77,8 @@ func StartDesiredVersion(binDir string, args []string) {
 	case internalV2Proxy:
 		p = path.Join(binDir, "2", "etcd")
 		if _, err := os.Stat(standbyInfo4(fs.Lookup("data-dir").Value.String())); err != nil {
-			fmt.Printf("etcd-starter: detected standby_info file. Adding --proxy=on flag to ensure node runs in v2.0 proxy mode.")
-			fmt.Printf("etcd-starter: before removing v0.4 data, --proxy=on flag MUST be added.")
+			fmt.Printf("etcd-starter: detected standby_info file. Adding --proxy=on flag to ensure node runs in v2.0 proxy mode.\n")
+			fmt.Printf("etcd-starter: before removing v0.4 data, --proxy=on flag MUST be added.\n")
 		}
 		// append proxy flag to args to trigger proxy mode
 		args = append(args, "-proxy=on")
@@ -86,7 +86,7 @@ func StartDesiredVersion(binDir string, args []string) {
 		log.Panicf("etcd-starter: unhandled start version")
 	}
 
-	fmt.Printf("etcd-starter: starting with %s %v with env %v", p, args, syscall.Environ())
+	fmt.Printf("etcd-starter: starting with %s %v with env %v\n", p, args, syscall.Environ())
 	err = syscall.Exec(p, append([]string{p}, args...), syscall.Environ())
 	if err != nil {
 		log.Fatalf("etcd-starter: failed to execute %s: %v", p, err)
@@ -103,7 +103,7 @@ func checkInternalVersion(fs *flag.FlagSet) version {
 
 	dataDir := fs.Lookup("data-dir").Value.String()
 	if dataDir == "" {
-		fmt.Printf("etcd-starter: data-dir is not set")
+		fmt.Printf("etcd-starter: data-dir is not set\n")
 		return internalV2
 	}
 	// check the data directory
@@ -111,7 +111,7 @@ func checkInternalVersion(fs *flag.FlagSet) version {
 	if err != nil {
 		log.Fatalf("etcd-starter: failed to detect etcd version in %v: %v", dataDir, err)
 	}
-	fmt.Printf("etcd-starter: detected etcd version %s in %s", dataver, dataDir)
+	fmt.Printf("etcd-starter: detected etcd version %s in %s\n", dataver, dataDir)
 	switch dataver {
 	case wal.WALv2_0:
 		return internalV2
@@ -128,7 +128,7 @@ func checkInternalVersion(fs *flag.FlagSet) version {
 		if inStandbyMode {
 			ver, err := checkInternalVersionByClientURLs(standbyInfo.ClientURLs(), clientTLSInfo(fs))
 			if err != nil {
-				fmt.Printf("etcd-starter: failed to check start version through peers: %v", err)
+				fmt.Printf("etcd-starter: failed to check start version through peers: %v\n", err)
 				return internalV1
 			}
 			if ver == internalV2 {
@@ -147,7 +147,7 @@ func checkInternalVersion(fs *flag.FlagSet) version {
 		discovery := fs.Lookup("discovery").Value.String()
 		dpeers, err := getPeersFromDiscoveryURL(discovery)
 		if err != nil {
-			fmt.Printf("etcd-starter: failed to get peers from discovery %s: %v", discovery, err)
+			fmt.Printf("etcd-starter: failed to get peers from discovery %s: %v\n", discovery, err)
 		}
 		peerStr := fs.Lookup("peers").Value.String()
 		ppeers := getPeersFromPeersFlag(peerStr, peerTLSInfo(fs))
@@ -155,12 +155,12 @@ func checkInternalVersion(fs *flag.FlagSet) version {
 		urls := getClientURLsByPeerURLs(append(dpeers, ppeers...), peerTLSInfo(fs))
 		ver, err := checkInternalVersionByClientURLs(urls, clientTLSInfo(fs))
 		if err != nil {
-			fmt.Printf("etcd-starter: failed to check start version through peers: %v", err)
+			fmt.Printf("etcd-starter: failed to check start version through peers: %v\n", err)
 			return internalV2
 		}
 		return ver
 	case wal.WALUnknown:
-		fmt.Printf("etcd-starter: unrecognized contents in data directory %s", dataDir)
+		fmt.Printf("etcd-starter: unrecognized contents in data directory %s\n", dataDir)
 		return internalV2
 	}
 	// never reach here
@@ -210,19 +210,19 @@ func checkInternalVersionByDataDir4(dataDir string) (version, error) {
 func getClientURLsByPeerURLs(peers []string, tls *TLSInfo) []string {
 	c, err := newDefaultClient(tls)
 	if err != nil {
-		fmt.Printf("etcd-starter: new client error: %v", err)
+		fmt.Printf("etcd-starter: new client error: %v\n", err)
 		return nil
 	}
 	var urls []string
 	for _, u := range peers {
 		resp, err := c.Get(u + "/etcdURL")
 		if err != nil {
-			fmt.Printf("etcd-starter: failed to get /etcdURL from %s", u)
+			fmt.Printf("etcd-starter: failed to get /etcdURL from %s\n", u)
 			continue
 		}
 		b, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			fmt.Printf("etcd-starter: failed to read body from %s", u)
+			fmt.Printf("etcd-starter: failed to read body from %s\n", u)
 			continue
 		}
 		urls = append(urls, string(b))
@@ -238,19 +238,19 @@ func checkInternalVersionByClientURLs(urls []string, tls *TLSInfo) (version, err
 	for _, u := range urls {
 		resp, err := c.Get(u + "/version")
 		if err != nil {
-			fmt.Printf("etcd-starter: failed to get /version from %s", u)
+			fmt.Printf("etcd-starter: failed to get /version from %s\n", u)
 			continue
 		}
 		b, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			fmt.Printf("etcd-starter: failed to read body from %s", u)
+			fmt.Printf("etcd-starter: failed to read body from %s\n", u)
 			continue
 		}
 
 		var m map[string]string
 		err = json.Unmarshal(b, &m)
 		if err != nil {
-			fmt.Printf("etcd-starter: failed to unmarshal body %s from %s", b, u)
+			fmt.Printf("etcd-starter: failed to unmarshal body %s from %s\n", b, u)
 			continue
 		}
 		switch m["internalVersion"] {
@@ -259,7 +259,7 @@ func checkInternalVersionByClientURLs(urls []string, tls *TLSInfo) (version, err
 		case "2":
 			return internalV2, nil
 		default:
-			fmt.Printf("etcd-starter: unrecognized internal version %s from %s", m["internalVersion"], u)
+			fmt.Printf("etcd-starter: unrecognized internal version %s from %s\n", m["internalVersion"], u)
 		}
 	}
 	return internalUnknown, fmt.Errorf("failed to get version from urls %v", urls)

--- a/starter/starter.go
+++ b/starter/starter.go
@@ -346,11 +346,12 @@ type boolFlag interface {
 // environment variables.
 func parseConfig(args []string) (*flag.FlagSet, error) {
 	fs := flag.NewFlagSet("full flagset", flag.ContinueOnError)
+	fs.Usage = func() {}
 	etcdmain.NewConfig().VisitAll(func(f *flag.Flag) {
 		_, isBoolFlag := f.Value.(boolFlag)
 		fs.Var(&value{isBoolFlag: isBoolFlag}, f.Name, "")
 	})
-	if err := fs.Parse(args); err != nil {
+	if err := fs.Parse(args); err != nil && err != flag.ErrHelp {
 		return nil, err
 	}
 	if err := flags.SetFlagsFromEnv(fs); err != nil {


### PR DESCRIPTION
help behavior:
```
unihorn@CoreOS ~/g/s/g/c/etcd-starter> go build && ETCD_INTERNAL_BINARY_DIR=./functional/.versions ./etcd-starter --help                                               1 master!?
etcd-starter: data-dir is not set
etcd-starter: starting etcd version 2
etcd-starter: starting with functional/.versions/2/etcd [--help] with env [PATH=/Users/unihorn/google-cloud-sdk/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Users/unihorn/gopath/bin TMPDIR=/var/folders/l5/jmwhr6wx75v7y68pgzfhk73c0000gn/T/ LOGNAME=unihorn XPC_FLAGS=0x0 HOME=/Users/unihorn Apple_PubSub_Socket_Render=/private/tmp/com.apple.launchd.knR6QLZsKg/Render TERM=xterm-256color COLORFGBG=7;0 USER=unihorn SSH_AUTH_SOCK=/var/folders/l5/jmwhr6wx75v7y68pgzfhk73c0000gn/T//ssh-9iOnP8HoVypF/agent.664 ITERM_PROFILE=Default TERM_PROGRAM=iTerm.app XPC_SERVICE_NAME=0 SHELL=/bin/zsh ITERM_SESSION_ID=w0t3p0 PWD=/Users/unihorn/gopath/src/github.com/coreos/etcd-starter __CF_USER_TEXT_ENCODING=0x1F5:0x19:0x34 LC_CTYPE=UTF-8 SHLVL=1 OLDPWD=/Users/unihorn/gopath/src/github.com/coreos/etcd-starter/functional ZSH=/Users/unihorn/.oh-my-zsh GOROOT=/usr/local/go GOPATH=/Users/unihorn/gopath VAGRANT_DEFAULT_PROVIDER=vmware_fusion PAGER=less LESS=-R LSCOLORS=Gxfxcxdxbxegedabagacad AUTOJUMP_DATA_DIR=/Users/unihorn/.local/share/autojump SSH_AGENT_PID=666 ETCD_V1_BIN=./etcd0.4 ETCD_V2_BIN=./etcd2.0 ETCDCTL_BIN=./etcdctl ETCD_STARTER_BIN=../etcd-starter ETCD_INTERNAL_BINARY_DIR=./functional/.versions _=/Users/unihorn/gopath/src/github.com/coreos/etcd-starter/./etcd-starter]
usage: etcd [flags]
       start an etcd server

       etcd --version
       show the version of etcd

       etcd -h | --help
       show the help information about etcd


member flags:
```